### PR TITLE
Mask string formatter

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,10 +14,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.0, 8.1]
-        laravel: [^8.67]
+        laravel: [^8.69]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: ^8.67
+          - laravel: ^8.69
             testbench: ^6.6
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 This package is a collection of classes you can use to standardize data formats in your Laravel application.
 It uses the Service Container to easily extend or override the formatter classes.
 
-The package requires PHP ^8.x and Laravel ^8.67.
+The package requires PHP `^8.x` and Laravel `^8.69`.
 
 [![PHP Version](https://img.shields.io/badge/php-^8.x-777BB4?style=flat-square&logo=php)](https://php.net)
 [![Laravel Version](https://img.shields.io/badge/laravel-^8.x-FF2D20?style=flat-square&logo=laravel)](https://laravel.com)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It uses the Service Container to easily extend or override the formatter classes
 The package requires PHP `^8.x` and Laravel `^8.69`.
 
 [![PHP Version](https://img.shields.io/badge/php-^8.x-777BB4?style=flat-square&logo=php)](https://php.net)
-[![Laravel Version](https://img.shields.io/badge/laravel-^8.x-FF2D20?style=flat-square&logo=laravel)](https://laravel.com)
+[![Laravel Version](https://img.shields.io/badge/laravel-^8.69-FF2D20?style=flat-square&logo=laravel)](https://laravel.com)
 [![Laravel Octane Compatible](https://img.shields.io/badge/octane-compatible-success?style=flat-square&logo=laravel)](https://github.com/laravel/octane)
 
 ## Available built-in formatters

--- a/README.md
+++ b/README.md
@@ -18,13 +18,12 @@ The package requires PHP `^8.x` and Laravel `^8.69`.
 [![Laravel Version](https://img.shields.io/badge/laravel-^8.x-FF2D20?style=flat-square&logo=laravel)](https://laravel.com)
 [![Laravel Octane Compatible](https://img.shields.io/badge/octane-compatible-success?style=flat-square&logo=laravel)](https://github.com/laravel/octane)
 
-## Available formatters
+## Available built-in formatters
 - [`Date`](https://github.com/michael-rubel/laravel-formatters/blob/main/src/Collection/DateFormatter.php)
 - [`DateTime`](https://github.com/michael-rubel/laravel-formatters/blob/main/src/Collection/DateTimeFormatter.php)
 - [`TableColumn`](https://github.com/michael-rubel/laravel-formatters/blob/main/src/Collection/TableColumnFormatter.php)
 - [`LocaleNumber`](https://github.com/michael-rubel/laravel-formatters/blob/main/src/Collection/LocaleNumberFormatter.php)
-
-... Will be more formatters soon. 😉
+- [`MaskString`](https://github.com/michael-rubel/laravel-formatters/blob/main/src/Collection/MaskStringFormatter.php)
 
 ## Contributing
 If you have written your own formatter and want to add it to this package, PRs are welcomed.

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.0|^8.1",
         "ext-intl": "*",
-        "laravel/framework": "^8.67",
+        "laravel/framework": "^8.69",
         "spatie/laravel-package-tools": "^1.9"
     },
     "require-dev": {

--- a/src/Collection/MaskEmailFormatter.php
+++ b/src/Collection/MaskEmailFormatter.php
@@ -31,7 +31,7 @@ class MaskEmailFormatter implements Formatter
     public string $encoding = 'UTF-8';
 
     /**
-     * Format the snake-cased attributes in readable format for the tables.
+     * Format email as masked.
      *
      * @param Collection $items
      *

--- a/src/Collection/MaskEmailFormatter.php
+++ b/src/Collection/MaskEmailFormatter.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MichaelRubel\Formatters\Collection;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use MichaelRubel\Formatters\Formatter;
+
+class MaskEmailFormatter implements Formatter
+{
+    /**
+     * @var string
+     */
+    public string $character = '*';
+
+    /**
+     * @var int
+     */
+    public int $index = 4;
+
+    /**
+     * @var int
+     */
+    public int $length = -4;
+
+    /**
+     * @var string
+     */
+    public string $encoding = 'UTF-8';
+
+    /**
+     * Format the snake-cased attributes in readable format for the tables.
+     *
+     * @param Collection $items
+     *
+     * @return string
+     */
+    public function format(Collection $items): string
+    {
+        return Str::mask(
+            (string) $items->first(),
+            $this->character,
+            $this->index,
+            $this->length,
+            $this->encoding
+        );
+    }
+}

--- a/src/Collection/MaskStringFormatter.php
+++ b/src/Collection/MaskStringFormatter.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use MichaelRubel\Formatters\Formatter;
 
-class MaskEmailFormatter implements Formatter
+class MaskStringFormatter implements Formatter
 {
     /**
      * @var string

--- a/tests/MaskEmailFormatterTest.php
+++ b/tests/MaskEmailFormatterTest.php
@@ -7,7 +7,7 @@ use MichaelRubel\Formatters\Collection\MaskStringFormatter;
 class MaskEmailFormatterTest extends TestCase
 {
     /** @test */
-    public function testCanFormatAsMaskedEmail()
+    public function testCanFormatStringAsMasked()
     {
         $format = format(MaskStringFormatter::class, 'MyMaskedString');
         $this->assertSame('MyMa******ring', $format);

--- a/tests/MaskEmailFormatterTest.php
+++ b/tests/MaskEmailFormatterTest.php
@@ -10,11 +10,15 @@ class MaskEmailFormatterTest extends TestCase
     public function testCanFormatAsMaskedEmail()
     {
         $format = format(MaskStringFormatter::class, 'MyMaskedString');
-
         $this->assertSame('MyMa******ring', $format);
 
         $format = format(MaskStringFormatter::class, 'test@example.com');
-
         $this->assertSame('test********.com', $format);
+
+        $format = format(MaskStringFormatter::class, 'testTestT');
+        $this->assertSame('test*estT', $format);
+
+        $format = format(MaskStringFormatter::class, 'tes');
+        $this->assertSame('tes', $format);
     }
 }

--- a/tests/MaskEmailFormatterTest.php
+++ b/tests/MaskEmailFormatterTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace MichaelRubel\Formatters\Tests;
+
+use MichaelRubel\Formatters\Collection\MaskEmailFormatter;
+
+class MaskEmailFormatterTest extends TestCase
+{
+    /** @test */
+    public function testCanFormatAsMaskedEmail()
+    {
+        $format = format(MaskEmailFormatter::class, 'test@example.com');
+
+        $this->assertSame('test********.com', $format);
+
+        $format = format(MaskEmailFormatter::class, 'masked@example.org');
+
+        $this->assertSame('mask**********.org', $format);
+    }
+}

--- a/tests/MaskEmailFormatterTest.php
+++ b/tests/MaskEmailFormatterTest.php
@@ -2,19 +2,19 @@
 
 namespace MichaelRubel\Formatters\Tests;
 
-use MichaelRubel\Formatters\Collection\MaskEmailFormatter;
+use MichaelRubel\Formatters\Collection\MaskStringFormatter;
 
 class MaskEmailFormatterTest extends TestCase
 {
     /** @test */
     public function testCanFormatAsMaskedEmail()
     {
-        $format = format(MaskEmailFormatter::class, 'test@example.com');
+        $format = format(MaskStringFormatter::class, 'MyMaskedString');
+
+        $this->assertSame('MyMa******ring', $format);
+
+        $format = format(MaskStringFormatter::class, 'test@example.com');
 
         $this->assertSame('test********.com', $format);
-
-        $format = format(MaskEmailFormatter::class, 'masked@example.org');
-
-        $this->assertSame('mask**********.org', $format);
     }
 }


### PR DESCRIPTION
#### The class that formats passed string as masked.

Required Laravel version: `8.69`.