### PR TITLE
Code change you can make to align with PHP 7.4

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.0, 8.1]
+        php: [7.4, 8.0, 8.1]
         laravel: [^8.69]
         stability: [prefer-lowest, prefer-stable]
         include:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.0|^8.1",
+        "php": "^7.4|^8.0|^8.1",
         "ext-intl": "*",
         "laravel/framework": "^8.69",
         "spatie/laravel-package-tools": "^1.9"

--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -11,7 +11,7 @@ if (! function_exists('format')) {
      *
      * @return mixed
      */
-    function format(string $formatter, /* mixed */ $items) /*: mixed */
+    function format(string $formatter, $items)
     {
         $formatter = class_exists($formatter) || interface_exists($formatter)
             ? app($formatter)

--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -11,7 +11,7 @@ if (! function_exists('format')) {
      *
      * @return mixed
      */
-    function format(string $formatter, mixed $items): mixed
+    function format(string $formatter, /* mixed */ $items) /*: mixed */
     {
         $formatter = class_exists($formatter) || interface_exists($formatter)
             ? app($formatter)


### PR DESCRIPTION
These are the changes to align with PHP 7.4 that I see.

Just one test fails:
• MichaelRubel\Formatters\Tests\FormatterBindingsTest > string bindings with camel case is forbidden
  Failed asserting that exception of type "Illuminate\Contracts\Container\BindingResolutionException" matches expected exception "MichaelRubel\Formatters\Exceptions\ShouldNotUseCamelCaseException". Message was: "Unresolvable dependency resolving [Parameter #0 [ <optional> $time ]] in class DateTime" at
  V:\sys\laragon\www\laravel-formatters\vendor\laravel\framework\src\Illuminate\Container\Container.php:1108
  