### PR TITLE
Update Laravel Pint & Remove redundant `now` assignments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "brianium/paratest": "^6.3",
-        "laravel/pint": "^1.1",
+        "laravel/pint": "^0.2.1",
         "mockery/mockery": "^1.4.4",
         "nunomaduro/collision": "^5.10|^6.0",
         "nunomaduro/larastan": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "brianium/paratest": "^6.3",
-        "laravel/pint": "^0.2.1",
+        "laravel/pint": "^1.1",
         "mockery/mockery": "^1.4.4",
         "nunomaduro/collision": "^5.10|^6.0",
         "nunomaduro/larastan": "^1.0",

--- a/pint.json
+++ b/pint.json
@@ -9,6 +9,10 @@
       "elements": {
         "const": "only_if_meta"
       }
+    },
+    "binary_operator_spaces": {
+      "default": "single_space",
+      "operators": {"=>": null, "=": "align_single_space_minimal"}
     }
   }
 }

--- a/src/Collection/DateFormatter.php
+++ b/src/Collection/DateFormatter.php
@@ -24,10 +24,6 @@ class DateFormatter implements Formatter
             $this->timezone = config('app.timezone', 'UTC');
         }
 
-        if (! $this->date) {
-            $this->date = now();
-        }
-
         if (! $this->date instanceof CarbonInterface) {
             $this->date = app(Carbon::class)->parse($this->date);
         }

--- a/src/Collection/DateTimeFormatter.php
+++ b/src/Collection/DateTimeFormatter.php
@@ -24,10 +24,6 @@ class DateTimeFormatter implements Formatter
             $this->timezone = config('app.timezone', 'UTC');
         }
 
-        if (! $this->datetime) {
-            $this->datetime = now();
-        }
-
         if (! $this->datetime instanceof CarbonInterface) {
             $this->datetime = app(Carbon::class)->parse($this->datetime);
         }

--- a/src/Collection/TaxNumberFormatter.php
+++ b/src/Collection/TaxNumberFormatter.php
@@ -18,8 +18,8 @@ class TaxNumberFormatter implements Formatter
         public ?string $country = null
     ) {
         $filteredTaxNumber = preg_replace_array('/[^\d\w]/', [], (string) $this->tax_number);
-        $this->tax_number = Str::upper($filteredTaxNumber);
-        $this->country = Str::upper((string) $this->country);
+        $this->tax_number  = Str::upper($filteredTaxNumber);
+        $this->country     = Str::upper((string) $this->country);
     }
 
     /**

--- a/src/FormatterServiceInterface.php
+++ b/src/FormatterServiceInterface.php
@@ -11,7 +11,7 @@ interface FormatterServiceInterface
      *
      * @const
      */
-    public const PACKAGE_FOLDER = 'Collection';
+    public const PACKAGE_FOLDER  = 'Collection';
     public const BINDING_POSTFIX = '_formatter';
     public const CLASS_SEPARATOR = '\\';
 }

--- a/src/FormatterServiceProvider.php
+++ b/src/FormatterServiceProvider.php
@@ -61,8 +61,8 @@ class FormatterServiceProvider extends PackageServiceProvider
             ->merge($appFormatters)
             ->each(function ($file) use ($app_folder, $bindings_case) {
                 $filename = $file->getFilenameWithoutExtension();
-                $name = $this->getFormatterName($bindings_case, $filename);
-                $class = $this->getFormatterClass($file, $filename, $app_folder);
+                $name     = $this->getFormatterName($bindings_case, $filename);
+                $class    = $this->getFormatterClass($file, $filename, $app_folder);
 
                 $this->app->bind($name, $class);
             });

--- a/tests/DateFormatterTest.php
+++ b/tests/DateFormatterTest.php
@@ -137,7 +137,7 @@ class DateFormatterTest extends TestCase
         $this->assertEquals('2021-10-31', $result);
 
         app()->extend(DateFormatter::class, function ($service) {
-            $service->timezone = 'Europe/Warsaw';
+            $service->timezone    = 'Europe/Warsaw';
             $service->date_format = 'd-m-Y';
 
             return $service;

--- a/tests/DateTimeFormatterTest.php
+++ b/tests/DateTimeFormatterTest.php
@@ -128,7 +128,7 @@ class DateTimeFormatterTest extends TestCase
         $this->assertEquals('2021-10-31 00:00', $result);
 
         app()->extend(DateTimeFormatter::class, function ($service) {
-            $service->timezone = 'Europe/Warsaw';
+            $service->timezone        = 'Europe/Warsaw';
             $service->datetime_format = 'Y-m-d H:i:s';
 
             return $service;

--- a/tests/FormatterConfigTest.php
+++ b/tests/FormatterConfigTest.php
@@ -20,7 +20,7 @@ class FormatterConfigTest extends TestCase
         app()->instance('files', $mock);
 
         config([
-            'formatters.folder'        => null,
+            'formatters.folder' => null,
             'formatters.bindings_case' => null,
         ]);
 

--- a/tests/FormatterConfigTest.php
+++ b/tests/FormatterConfigTest.php
@@ -20,7 +20,7 @@ class FormatterConfigTest extends TestCase
         app()->instance('files', $mock);
 
         config([
-            'formatters.folder' => null,
+            'formatters.folder'        => null,
             'formatters.bindings_case' => null,
         ]);
 

--- a/tests/MaskStringFormatterTest.php
+++ b/tests/MaskStringFormatterTest.php
@@ -53,11 +53,11 @@ class MaskStringFormatterTest extends TestCase
     public function testCanExtendFormatterBinding()
     {
         extend(MaskStringFormatter::class, function ($formatter) {
-            $formatter->string = 'test@example.com';
+            $formatter->string    = 'test@example.com';
             $formatter->character = '%';
-            $formatter->index = 5;
-            $formatter->length = -5;
-            $formatter->encoding = 'KOI8-U';
+            $formatter->index     = 5;
+            $formatter->length    = -5;
+            $formatter->encoding  = 'KOI8-U';
 
             $this->assertStringContainsString('test@example.com', $formatter->string);
             $this->assertStringContainsString('%', $formatter->character);

--- a/tests/TaxNumberFormatterTest.php
+++ b/tests/TaxNumberFormatterTest.php
@@ -11,7 +11,7 @@ class TaxNumberFormatterTest extends TestCase
     {
         $result = format(TaxNumberFormatter::class, [
             'tax_number' => '0123456789',
-            'country'    => 'UA',
+            'country' => 'UA',
         ]);
 
         $this->assertEquals('UA0123456789', $result);
@@ -32,7 +32,7 @@ class TaxNumberFormatterTest extends TestCase
     {
         $result = format(TaxNumberFormatter::class, [
             'tax_number' => '0123456789',
-            'country'    => 'pl',
+            'country' => 'pl',
         ]);
 
         $this->assertEquals('PL0123456789', $result);
@@ -43,7 +43,7 @@ class TaxNumberFormatterTest extends TestCase
     {
         $result = format(TaxNumberFormatter::class, [
             'tax_number' => '0123456789',
-            'country'    => '',
+            'country' => '',
         ]);
 
         $this->assertEquals('0123456789', $result);
@@ -64,7 +64,7 @@ class TaxNumberFormatterTest extends TestCase
     {
         $result = format(TaxNumberFormatter::class, [
             'tax_number' => 'FR0123456789',
-            'country'    => 'PL',
+            'country' => 'PL',
         ]);
 
         $this->assertEquals('PLFR0123456789', $result);
@@ -75,7 +75,7 @@ class TaxNumberFormatterTest extends TestCase
     {
         $result = format(TaxNumberFormatter::class, [
             'tax_number' => '+01 23-45.67,89',
-            'country'    => 'pL',
+            'country' => 'pL',
         ]);
 
         $this->assertEquals('PL0123456789', $result);
@@ -86,7 +86,7 @@ class TaxNumberFormatterTest extends TestCase
     {
         $result = format(TaxNumberFormatter::class, [
             'tax_number' => 'PL0123456789',
-            'country'    => 'pL',
+            'country' => 'pL',
         ]);
 
         $this->assertEquals('PL0123456789', $result);
@@ -97,7 +97,7 @@ class TaxNumberFormatterTest extends TestCase
     {
         $result = format(TaxNumberFormatter::class, [
             'tax_number' => 'pL0123456789',
-            'country'    => 'pl',
+            'country' => 'pl',
         ]);
 
         $this->assertEquals('PL0123456789', $result);
@@ -108,7 +108,7 @@ class TaxNumberFormatterTest extends TestCase
     {
         $result = format(TaxNumberFormatter::class, [
             'tax_number' => '',
-            'country'    => '',
+            'country' => '',
         ]);
 
         $this->assertEquals('', $result);
@@ -129,7 +129,7 @@ class TaxNumberFormatterTest extends TestCase
     {
         $result = format('tax-number', [
             'tax_number' => '0123456789',
-            'country'    => 'UA',
+            'country' => 'UA',
         ]);
 
         $this->assertEquals('UA0123456789', $result);
@@ -168,7 +168,7 @@ class TaxNumberFormatterTest extends TestCase
 
         $result = format(TaxNumberFormatter::class, [
             'tax_number' => 'extend has priority',
-            'country'    => 'extend has priority',
+            'country' => 'extend has priority',
         ]);
 
         $this->assertEquals('UA0123456789', $result);

--- a/tests/TaxNumberFormatterTest.php
+++ b/tests/TaxNumberFormatterTest.php
@@ -161,7 +161,7 @@ class TaxNumberFormatterTest extends TestCase
     {
         extend(TaxNumberFormatter::class, function ($formatter) {
             $formatter->tax_number = 'UA0123456789';
-            $formatter->country = 'UA';
+            $formatter->country    = 'UA';
 
             return $formatter;
         });

--- a/tests/TaxNumberFormatterTest.php
+++ b/tests/TaxNumberFormatterTest.php
@@ -11,7 +11,7 @@ class TaxNumberFormatterTest extends TestCase
     {
         $result = format(TaxNumberFormatter::class, [
             'tax_number' => '0123456789',
-            'country' => 'UA',
+            'country'    => 'UA',
         ]);
 
         $this->assertEquals('UA0123456789', $result);
@@ -32,7 +32,7 @@ class TaxNumberFormatterTest extends TestCase
     {
         $result = format(TaxNumberFormatter::class, [
             'tax_number' => '0123456789',
-            'country' => 'pl',
+            'country'    => 'pl',
         ]);
 
         $this->assertEquals('PL0123456789', $result);
@@ -43,7 +43,7 @@ class TaxNumberFormatterTest extends TestCase
     {
         $result = format(TaxNumberFormatter::class, [
             'tax_number' => '0123456789',
-            'country' => '',
+            'country'    => '',
         ]);
 
         $this->assertEquals('0123456789', $result);
@@ -64,7 +64,7 @@ class TaxNumberFormatterTest extends TestCase
     {
         $result = format(TaxNumberFormatter::class, [
             'tax_number' => 'FR0123456789',
-            'country' => 'PL',
+            'country'    => 'PL',
         ]);
 
         $this->assertEquals('PLFR0123456789', $result);
@@ -75,7 +75,7 @@ class TaxNumberFormatterTest extends TestCase
     {
         $result = format(TaxNumberFormatter::class, [
             'tax_number' => '+01 23-45.67,89',
-            'country' => 'pL',
+            'country'    => 'pL',
         ]);
 
         $this->assertEquals('PL0123456789', $result);
@@ -86,7 +86,7 @@ class TaxNumberFormatterTest extends TestCase
     {
         $result = format(TaxNumberFormatter::class, [
             'tax_number' => 'PL0123456789',
-            'country' => 'pL',
+            'country'    => 'pL',
         ]);
 
         $this->assertEquals('PL0123456789', $result);
@@ -97,7 +97,7 @@ class TaxNumberFormatterTest extends TestCase
     {
         $result = format(TaxNumberFormatter::class, [
             'tax_number' => 'pL0123456789',
-            'country' => 'pl',
+            'country'    => 'pl',
         ]);
 
         $this->assertEquals('PL0123456789', $result);
@@ -108,7 +108,7 @@ class TaxNumberFormatterTest extends TestCase
     {
         $result = format(TaxNumberFormatter::class, [
             'tax_number' => '',
-            'country' => '',
+            'country'    => '',
         ]);
 
         $this->assertEquals('', $result);
@@ -129,7 +129,7 @@ class TaxNumberFormatterTest extends TestCase
     {
         $result = format('tax-number', [
             'tax_number' => '0123456789',
-            'country' => 'UA',
+            'country'    => 'UA',
         ]);
 
         $this->assertEquals('UA0123456789', $result);
@@ -168,7 +168,7 @@ class TaxNumberFormatterTest extends TestCase
 
         $result = format(TaxNumberFormatter::class, [
             'tax_number' => 'extend has priority',
-            'country' => 'extend has priority',
+            'country'    => 'extend has priority',
         ]);
 
         $this->assertEquals('UA0123456789', $result);


### PR DESCRIPTION
### About
- Removes redundant `now` assignments;
- Updates Laravel Pint & applies style differences.