### PR TITLE
Change behavior of date formatters

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,13 +16,14 @@ parameters:
         - '#Parameter \#1 \$array of function current expects array\|object, mixed given\.#'
         - '#Parameter \#1 \$value of function count expects array\|Countable, mixed given\.#'
         - '#Property MichaelRubel\\Formatters\\Collection\\DateTimeFormatter\:\:\$timezone \(string\|null\) does not accept mixed\.#'
-        - '#Cannot call method setTimezone\(\) on Carbon\\CarbonInterface\|string\|null\.#'
+        - '#Cannot call method setTimezone\(\) on Carbon\\CarbonInterface\|string\.#'
         - '#Property MichaelRubel\\Formatters\\Collection\\DateFormatter\:\:\$timezone \(string\|null\) does not accept mixed\.#'
         - '#Parameter \#1 \$needles of method Illuminate\\Support\\Stringable\:\:startsWith\(\) expects array\<string\>\|string, string\|null given\.#'
         - '#Parameter \#3 \$subject of static method Illuminate\\Support\\Str\:\:replace\(\) expects array\<string\>\|string, string\|null given\.#'
         - '#(.*)expects string, string\|null given\.#'
         - '#Parameter \#1 \$formatter of static method MichaelRubel\\Formatters\\FormatterService\:\:ensureFormatterImplementsInterface\(\) expects object, mixed given\.#'
         - '#Call to an undefined method MichaelRubel\\EnhancedContainer\\Core\\CallProxy\:\:format\(\)\.#'
+        - '##'
 
     checkMissingIterableValueType: false
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -23,7 +23,6 @@ parameters:
         - '#(.*)expects string, string\|null given\.#'
         - '#Parameter \#1 \$formatter of static method MichaelRubel\\Formatters\\FormatterService\:\:ensureFormatterImplementsInterface\(\) expects object, mixed given\.#'
         - '#Call to an undefined method MichaelRubel\\EnhancedContainer\\Core\\CallProxy\:\:format\(\)\.#'
-        - '##'
 
     checkMissingIterableValueType: false
 

--- a/src/Collection/DateFormatter.php
+++ b/src/Collection/DateFormatter.php
@@ -20,23 +20,26 @@ class DateFormatter implements Formatter
         public string|null $timezone = null,
         public string|null $date_format = 'Y-m-d',
     ) {
-        if (! $this->date instanceof CarbonInterface) {
+        if (empty($this->date)) {
+            $this->date = null;
+        }
+
+        if (is_string($this->date)) {
             $this->date = app(Carbon::class)->parse($this->date);
         }
 
-        $this->timezone    = $this->timezone ?? config('app.timezone', 'UTC');
-        $this->date_format = $this->date_format ?? 'Y-m-d';
+        $this->timezone ??= config('app.timezone', 'UTC');
     }
 
     /**
      * Format the date.
      *
-     * @return string
+     * @return string|null
      */
-    public function format(): string
+    public function format(): ?string
     {
         return $this->date
-            ->setTimezone($this->timezone)
+            ?->setTimezone($this->timezone)
             ->translatedFormat($this->date_format);
     }
 }

--- a/src/Collection/DateTimeFormatter.php
+++ b/src/Collection/DateTimeFormatter.php
@@ -20,23 +20,26 @@ class DateTimeFormatter implements Formatter
         public string|null $timezone = null,
         public string|null $datetime_format = 'Y-m-d H:i',
     ) {
-        if (! $this->datetime instanceof CarbonInterface) {
+        if (empty($this->datetime)) {
+            $this->datetime = null;
+        }
+
+        if (is_string($this->datetime)) {
             $this->datetime = app(Carbon::class)->parse($this->datetime);
         }
 
-        $this->timezone        = $this->timezone ?? config('app.timezone', 'UTC');
-        $this->datetime_format = $this->datetime_format ?? 'Y-m-d H:i';
+        $this->timezone ??= config('app.timezone', 'UTC');
     }
 
     /**
      * Format the date and time.
      *
-     * @return string
+     * @return string|null
      */
-    public function format(): string
+    public function format(): ?string
     {
         return $this->datetime
-            ->setTimezone($this->timezone)
+            ?->setTimezone($this->timezone)
             ->translatedFormat($this->datetime_format);
     }
 }

--- a/tests/DateFormatterTest.php
+++ b/tests/DateFormatterTest.php
@@ -96,13 +96,13 @@ class DateFormatterTest extends TestCase
     public function testFormatBehaviorWithNullOrEmpty()
     {
         $format = format('date');
-        $this->assertSame('2021-10-30', $format);
+        $this->assertNull($format);
 
         $format = format('date', '');
-        $this->assertSame('2021-10-30', $format);
+        $this->assertNull($format);
 
         $format = format('date', null);
-        $this->assertSame('2021-10-30', $format);
+        $this->assertNull($format);
     }
 
     /** @test */

--- a/tests/DateTimeFormatterTest.php
+++ b/tests/DateTimeFormatterTest.php
@@ -87,13 +87,13 @@ class DateTimeFormatterTest extends TestCase
     public function testFormatBehaviorWithNullOrEmpty()
     {
         $format = format('date-time');
-        $this->assertSame('2021-10-30 14:00', $format);
+        $this->assertNull($format);
 
         $format = format('date-time', '');
-        $this->assertSame('2021-10-30 14:00', $format);
+        $this->assertNull($format);
 
         $format = format('date-time', null);
-        $this->assertSame('2021-10-30 14:00', $format);
+        $this->assertNull($format);
     }
 
     /** @test */


### PR DESCRIPTION
## About
When we're working with date/datetime formatters, we need to make sure the date is not null. Otherwise, the `format` helper returns the current date. It is considered wrong behavior because most times current date is unexpected by the developer.

This PR changes the date formatters, so all `null` and empty values are now handled by returning `null` by the `format` helper. 

> Before:
```php
! empty($datetime) ? format('date', $datetime) : __('No data')
```

> After:
```php
format('date', $datetime) ?? __('No data')
```

This change is breaking, so it'll be published at the `v5` of the package.
