### PR TITLE
Drop Laravel 8 support

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -17,7 +17,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.0'
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl, gd
           coverage: none
 
       - name: Cache composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,13 +14,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.0, 8.1]
-        laravel: [^8.71, 9.*]
+        laravel: [9.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - testbench: 7.*
             laravel: 9.*
-          - testbench: ^6.6
-            laravel: ^8.71
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ This package introduces the `Formatter` pattern you can use to standardize data 
 
 ---
 
-The package requires PHP `^8.x` and Laravel `^8.71` or `^9.0`.
+Latest version of the package requires PHP `8.x` and Laravel `9.x`.
+If you're looking for older versions, check [release history](https://github.com/michael-rubel/laravel-formatters/releases).
+
 
 ## #StandWithUkraine
 [![SWUbanner](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/banner2-direct.svg)](https://github.com/vshymanskyy/StandWithUkraine/blob/main/docs/README.md)

--- a/composer.json
+++ b/composer.json
@@ -18,18 +18,18 @@
     "require": {
         "php": "^8.0",
         "ext-intl": "*",
-        "michael-rubel/laravel-enhanced-container": "^6.4|^8.0|^9.0",
-        "spatie/laravel-package-tools": "^1.9"
+        "michael-rubel/laravel-enhanced-container": "^9.2",
+        "spatie/laravel-package-tools": "^1.12"
     },
     "require-dev": {
         "brianium/paratest": "^6.3",
         "laravel/pint": "^1.1",
         "mockery/mockery": "^1.4.4",
-        "nunomaduro/collision": "^5.10|^6.0",
-        "nunomaduro/larastan": "^1.0",
-        "orchestra/testbench": "^6.6|^7.0",
+        "nunomaduro/collision": "^6.0",
+        "nunomaduro/larastan": "^2.2",
+        "orchestra/testbench": "^7.0",
         "phpunit/phpunit": "^9.5",
-        "roave/backward-compatibility-check": "^6.4|^7.0"
+        "roave/backward-compatibility-check": "^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,8 +10,7 @@ parameters:
 
     ignoreErrors:
         - '#Property MichaelRubel\\Formatters\\Exceptions\\(.*)Exception\:\:\$message has no type specified\.#'
-        - '#Cannot call method getInternal\(\) on mixed\.#'
-        - '#Cannot call method format\(\) on mixed\.#'
+        - '#Cannot call method (.*) on mixed\.#'
         - '#Parameter \#2 \$parameters of function call expects array, mixed given\.#'
         - '#Parameter \#1 \$array of function current expects array\|object, mixed given\.#'
         - '#Parameter \#1 \$value of function count expects array\|Countable, mixed given\.#'
@@ -29,3 +28,6 @@ parameters:
     reportUnmatchedIgnoredErrors: false
 
     checkOctaneCompatibility: true
+
+    checkGenericClassInNonGenericObjectType: false
+

--- a/src/Collection/LocaleNumberFormatter.php
+++ b/src/Collection/LocaleNumberFormatter.php
@@ -31,16 +31,9 @@ class LocaleNumberFormatter implements Formatter
     ) {
         $this->locale = $this->locale ?? app()->getLocale();
 
-        $this->formatter = new NumberFormatter(
-            $this->locale,
-            $this->style,
-            $this->pattern
-        );
+        $this->formatter = new NumberFormatter($this->locale, $this->style, $this->pattern);
 
-        $this->formatter->setAttribute(
-            NumberFormatter::FRACTION_DIGITS,
-            $this->fraction_digits
-        );
+        $this->formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $this->fraction_digits);
     }
 
     /**

--- a/src/Collection/MaskStringFormatter.php
+++ b/src/Collection/MaskStringFormatter.php
@@ -32,12 +32,8 @@ class MaskStringFormatter implements Formatter
      */
     public function format(): string
     {
-        return Str::mask(
-            (string) $this->string,
-            $this->character,
-            $this->index,
-            $this->length,
-            $this->encoding
-        );
+        return str($this->string)
+            ->mask($this->character, $this->index, $this->length, $this->encoding)
+            ->value();
     }
 }

--- a/src/Collection/MaskStringFormatter.php
+++ b/src/Collection/MaskStringFormatter.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MichaelRubel\Formatters\Collection;
 
-use Illuminate\Support\Str;
 use MichaelRubel\Formatters\Formatter;
 
 class MaskStringFormatter implements Formatter

--- a/src/Collection/TableColumnFormatter.php
+++ b/src/Collection/TableColumnFormatter.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MichaelRubel\Formatters\Collection;
 
-use Illuminate\Support\Str;
 use MichaelRubel\Formatters\Formatter;
 
 class TableColumnFormatter implements Formatter
@@ -24,12 +23,9 @@ class TableColumnFormatter implements Formatter
      */
     public function format(): string
     {
-        return Str::ucfirst(
-            Str::replace(
-                '_',
-                ' ',
-                (string) $this->attribute
-            )
-        );
+        return str($this->attribute)
+            ->ucfirst()
+            ->replace('_', ' ')
+            ->value();
     }
 }

--- a/src/Collection/TaxNumberFormatter.php
+++ b/src/Collection/TaxNumberFormatter.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MichaelRubel\Formatters\Collection;
 
-use Illuminate\Support\Str;
 use MichaelRubel\Formatters\Formatter;
 
 class TaxNumberFormatter implements Formatter
@@ -45,9 +44,10 @@ class TaxNumberFormatter implements Formatter
      */
     private function getPrefix(): string
     {
-        return (string) Str::of($this->tax_number)
+        return str($this->tax_number)
             ->substr(0, 2)
-            ->upper();
+            ->upper()
+            ->value();
     }
 
     /**

--- a/src/Collection/TaxNumberFormatter.php
+++ b/src/Collection/TaxNumberFormatter.php
@@ -55,8 +55,8 @@ class TaxNumberFormatter implements Formatter
      */
     private function getFullTaxNumber(): string
     {
-        return str($this->getPrefix())->startsWith($this->country)
-            ? str($this->tax_number)->substr(2)->start($this->country)->value()
-            : str($this->tax_number)->start($this->country)->value();
+        return ! str($this->getPrefix())->startsWith($this->country)
+            ? str($this->tax_number)->start($this->country)->value()
+            : str($this->tax_number)->substr(2)->start($this->country)->value();
     }
 }

--- a/src/Collection/TaxNumberFormatter.php
+++ b/src/Collection/TaxNumberFormatter.php
@@ -55,17 +55,8 @@ class TaxNumberFormatter implements Formatter
      */
     private function getFullTaxNumber(): string
     {
-        $prefixStartsWithCountry = str($this->getPrefix())->startsWith($this->country);
-
-        if ($prefixStartsWithCountry) {
-            return str($this->tax_number)
-                ->substr(2)
-                ->start($this->country)
-                ->value();
-        }
-
-        return str($this->tax_number)
-            ->start($this->country)
-            ->value();
+        return str($this->getPrefix())->startsWith($this->country)
+            ? str($this->tax_number)->substr(2)->start($this->country)->value()
+            : str($this->tax_number)->start($this->country)->value();
     }
 }

--- a/src/Collection/TaxNumberFormatter.php
+++ b/src/Collection/TaxNumberFormatter.php
@@ -18,8 +18,14 @@ class TaxNumberFormatter implements Formatter
         public ?string $country = null
     ) {
         $filteredTaxNumber = preg_replace_array('/[^\d\w]/', [], (string) $this->tax_number);
-        $this->tax_number  = Str::upper($filteredTaxNumber);
-        $this->country     = Str::upper((string) $this->country);
+
+        $this->tax_number = str($filteredTaxNumber)
+            ->upper()
+            ->value();
+
+        $this->country = str($this->country)
+            ->upper()
+            ->value();
     }
 
     /**
@@ -49,15 +55,17 @@ class TaxNumberFormatter implements Formatter
      */
     private function getFullTaxNumber(): string
     {
-        $prefixStartsWithCountry = Str::of($this->getPrefix())
-            ->startsWith($this->country);
+        $prefixStartsWithCountry = str($this->getPrefix())->startsWith($this->country);
 
         if ($prefixStartsWithCountry) {
-            return (string) Str::of($this->tax_number)
+            return str($this->tax_number)
                 ->substr(2)
-                ->start($this->country);
+                ->start($this->country)
+                ->value();
         }
 
-        return Str::start($this->tax_number, $this->country);
+        return str($this->tax_number)
+            ->start($this->country)
+            ->value();
     }
 }


### PR DESCRIPTION
## About
Laravel 8 already stopped receiving bug fixes, and the security fixes will stop in three months.
It's time to move forward and drop support of Laravel 8 in a new major version of the package.

`Larastan` code analysis tool also updated from `^1.0` to `^2.2`

---