### PR TITLE
Full-name formatter

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,11 +14,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.0, 8.1]
-        laravel: [9.*]
+        laravel: [^9.7]
         stability: [prefer-lowest, prefer-stable]
         include:
           - testbench: 7.*
-            laravel: 9.*
+            laravel: ^9.7
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This package introduces the `Formatter` pattern you can use to standardize data 
 
 ---
 
-Latest version of the package requires PHP `8.x` and Laravel `9.x`.
+Latest version of the package requires PHP `^8.0` and Laravel `^9.7`.
 If you're looking for older versions, check [release history](https://github.com/michael-rubel/laravel-formatters/releases).
 
 

--- a/config/formatters.php
+++ b/config/formatters.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+
     /*
     |--------------------------------------------------------------------------
     | Custom Formatters Folder
@@ -25,4 +26,5 @@ return [
     */
 
     'bindings_case' => 'kebab',
+
 ];

--- a/src/Collection/FullNameFormatter.php
+++ b/src/Collection/FullNameFormatter.php
@@ -15,7 +15,7 @@ class FullNameFormatter implements Formatter
     }
 
     /**
-     * Format the date.
+     * Format the full name.
      *
      * @return string
      */

--- a/src/Collection/FullNameFormatter.php
+++ b/src/Collection/FullNameFormatter.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace MichaelRubel\Formatters\Collection;
+
+use Illuminate\Support\Str;
+use MichaelRubel\Formatters\Formatter;
+
+class FullNameFormatter implements Formatter
+{
+    /**
+     * @param string|null $name
+     */
+    public function __construct(public ?string $name)
+    {
+        //
+    }
+
+    /**
+     * Format the date.
+     *
+     * @return string
+     */
+    public function format(): string
+    {
+        return Str::of($this->name)
+            ->squish()
+            ->headline()
+            ->value();
+    }
+}

--- a/src/Collection/FullNameFormatter.php
+++ b/src/Collection/FullNameFormatter.php
@@ -7,7 +7,7 @@ use MichaelRubel\Formatters\Formatter;
 class FullNameFormatter implements Formatter
 {
     /**
-     * @param string|null $name
+     * @param  string|null  $name
      */
     public function __construct(public ?string $name)
     {

--- a/src/Collection/FullNameFormatter.php
+++ b/src/Collection/FullNameFormatter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MichaelRubel\Formatters\Collection;
 
 use MichaelRubel\Formatters\Formatter;

--- a/src/Collection/FullNameFormatter.php
+++ b/src/Collection/FullNameFormatter.php
@@ -2,7 +2,6 @@
 
 namespace MichaelRubel\Formatters\Collection;
 
-use Illuminate\Support\Str;
 use MichaelRubel\Formatters\Formatter;
 
 class FullNameFormatter implements Formatter
@@ -22,7 +21,7 @@ class FullNameFormatter implements Formatter
      */
     public function format(): string
     {
-        return Str::of($this->name)
+        return str($this->name)
             ->squish()
             ->headline()
             ->value();

--- a/tests/FullNameFormatterTest.php
+++ b/tests/FullNameFormatterTest.php
@@ -34,16 +34,37 @@ class FullNameFormatterTest extends TestCase
         $this->assertSame('Michael Rubél', $name);
     }
 
-    public function testAddsSpaceBetweenWords()
+    public function testCutsSpaceBeforeAndAfter()
+    {
+        $name = format(FullNameFormatter::class, ' MichaelRubél ');
+
+        $this->assertSame('Michael Rubél', $name);
+    }
+
+    public function testAddsSpaceBetweenWordsOrHandlesPascalCase()
     {
         $name = format(FullNameFormatter::class, 'MichaelRubél');
 
         $this->assertSame('Michael Rubél', $name);
     }
 
-    public function testCutsSpaceBeforeAndAfter()
+    public function testHandlesSnakeCase()
     {
-        $name = format(FullNameFormatter::class, ' MichaelRubél ');
+        $name = format(FullNameFormatter::class, 'michael_rubél');
+
+        $this->assertSame('Michael Rubél', $name);
+    }
+
+    public function testHandlesCamelCase()
+    {
+        $name = format(FullNameFormatter::class, 'michaelRubél');
+
+        $this->assertSame('Michael Rubél', $name);
+    }
+
+    public function testHandlesKebabCase()
+    {
+        $name = format(FullNameFormatter::class, 'michael-rubél');
 
         $this->assertSame('Michael Rubél', $name);
     }

--- a/tests/FullNameFormatterTest.php
+++ b/tests/FullNameFormatterTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace MichaelRubel\Formatters\Tests;
+
+use MichaelRubel\Formatters\Collection\FullNameFormatter;
+
+class FullNameFormatterTest extends TestCase
+{
+    public function testCanUseStringBinding()
+    {
+        $name = format('full-name', 'michael');
+
+        $this->assertSame('Michael', $name);
+    }
+
+    public function testCanFormatFirstName()
+    {
+        $name = format(FullNameFormatter::class, 'michael');
+
+        $this->assertSame('Michael', $name);
+    }
+
+    public function testCanFormatLastName()
+    {
+        $name = format(FullNameFormatter::class, 'rubél');
+
+        $this->assertSame('Rubél', $name);
+    }
+
+    public function testCanFormatFirstAndLastName()
+    {
+        $name = format(FullNameFormatter::class, 'michaeL rubéL');
+
+        $this->assertSame('Michael Rubél', $name);
+    }
+
+    public function testAddsSpaceBetweenWords()
+    {
+        $name = format(FullNameFormatter::class, 'MichaelRubél');
+
+        $this->assertSame('Michael Rubél', $name);
+    }
+
+    public function testCutsSpaceBeforeAndAfter()
+    {
+        $name = format(FullNameFormatter::class, ' MichaelRubél ');
+
+        $this->assertSame('Michael Rubél', $name);
+    }
+
+    public function testEmptyStringAndWeirdSymbols()
+    {
+        $name = format(FullNameFormatter::class, '');
+        $this->assertSame('', $name);
+
+        $name = format(FullNameFormatter::class, '   ');
+        $this->assertSame('', $name);
+
+        $name = format(FullNameFormatter::class, '  ...  ');
+        $this->assertSame('...', $name);
+
+        $name = format(FullNameFormatter::class, '⠀');
+        $this->assertSame('⠀', $name);
+
+        $name = format(FullNameFormatter::class, ' ');
+        $this->assertSame('', $name);
+    }
+}

--- a/tests/FullNameFormatterTest.php
+++ b/tests/FullNameFormatterTest.php
@@ -69,21 +69,12 @@ class FullNameFormatterTest extends TestCase
         $this->assertSame('Michael Rubél', $name);
     }
 
-    public function testEmptyStringAndWeirdSymbols()
+    public function testEmptyString()
     {
         $name = format(FullNameFormatter::class, '');
         $this->assertSame('', $name);
 
         $name = format(FullNameFormatter::class, '   ');
-        $this->assertSame('', $name);
-
-        $name = format(FullNameFormatter::class, '  ...  ');
-        $this->assertSame('...', $name);
-
-        $name = format(FullNameFormatter::class, '⠀');
-        $this->assertSame('⠀', $name);
-
-        $name = format(FullNameFormatter::class, ' ');
         $this->assertSame('', $name);
     }
 }


### PR DESCRIPTION
## About
Formatter to clean up the regular full name.

Examples:
- `michael` becomes `Michael`
- `michaeL rubéL` becomes `Michael Rubél`
- `MichaelRubél` becomes `Michael Rubél`
- `⠀MichaelRubél⠀` becomes `Michael Rubél`
- `michael_rubél` becomes `Michael Rubél`