### PR TITLE
Update fullname formatter

### DIFF
--- a/src/Collection/FullNameFormatter.php
+++ b/src/Collection/FullNameFormatter.php
@@ -25,7 +25,7 @@ class FullNameFormatter implements Formatter
     {
         return str($this->name)
             ->squish()
-            ->headline()
+            ->title()
             ->value();
     }
 }

--- a/tests/FullNameFormatterTest.php
+++ b/tests/FullNameFormatterTest.php
@@ -34,6 +34,14 @@ class FullNameFormatterTest extends TestCase
         $this->assertSame('Michael Rubél', $name);
     }
 
+    public function testCanFormatNameWithMinusSeparators()
+    {
+        $name = format(FullNameFormatter::class, 'Anna Nowak-Kowalska');
+        $this->assertSame('Anna Nowak-Kowalska', $name);
+        $name = format(FullNameFormatter::class, ' anna nowak-kowalska ');
+        $this->assertSame('Anna Nowak-Kowalska', $name);
+    }
+
     public function testCutsSpaceBeforeAndAfter()
     {
         $name = format(FullNameFormatter::class, ' Michael Rubél ');

--- a/tests/FullNameFormatterTest.php
+++ b/tests/FullNameFormatterTest.php
@@ -36,35 +36,7 @@ class FullNameFormatterTest extends TestCase
 
     public function testCutsSpaceBeforeAndAfter()
     {
-        $name = format(FullNameFormatter::class, ' MichaelRubél ');
-
-        $this->assertSame('Michael Rubél', $name);
-    }
-
-    public function testAddsSpaceBetweenWordsOrHandlesPascalCase()
-    {
-        $name = format(FullNameFormatter::class, 'MichaelRubél');
-
-        $this->assertSame('Michael Rubél', $name);
-    }
-
-    public function testHandlesSnakeCase()
-    {
-        $name = format(FullNameFormatter::class, 'michael_rubél');
-
-        $this->assertSame('Michael Rubél', $name);
-    }
-
-    public function testHandlesCamelCase()
-    {
-        $name = format(FullNameFormatter::class, 'michaelRubél');
-
-        $this->assertSame('Michael Rubél', $name);
-    }
-
-    public function testHandlesKebabCase()
-    {
-        $name = format(FullNameFormatter::class, 'michael-rubél');
+        $name = format(FullNameFormatter::class, ' Michael Rubél ');
 
         $this->assertSame('Michael Rubél', $name);
     }


### PR DESCRIPTION
## About
With the current implementation, this is impossible to format names like `Anna Nowak-Kowalska`, because it will split the last name like "Anna Nowak Kowalska".

Swapping the `headline` with `title` stringable method resolves the problem, but at the same time removes support for different separators, like the snake_case.