### PR TITLE
Add `Name` formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,10 @@ format('date-time', now());
 ## Available built-in formatters
 - [`Date`](https://github.com/michael-rubel/laravel-formatters/blob/main/src/Collection/DateFormatter.php)
 - [`DateTime`](https://github.com/michael-rubel/laravel-formatters/blob/main/src/Collection/DateTimeFormatter.php)
+- [`FullName`](https://github.com/michael-rubel/laravel-formatters/blob/main/src/Collection/FullNameFormatter.php)
 - [`LocaleNumber`](https://github.com/michael-rubel/laravel-formatters/blob/main/src/Collection/LocaleNumberFormatter.php)
 - [`MaskString`](https://github.com/michael-rubel/laravel-formatters/blob/main/src/Collection/MaskStringFormatter.php)
+- [`Name`](https://github.com/michael-rubel/laravel-formatters/blob/main/src/Collection/NameFormatter.php)
 - [`TableColumn`](https://github.com/michael-rubel/laravel-formatters/blob/main/src/Collection/TableColumnFormatter.php)
 - [`TaxNumber`](https://github.com/michael-rubel/laravel-formatters/blob/main/src/Collection/TaxNumberFormatter.php)
 

--- a/src/Collection/NameFormatter.php
+++ b/src/Collection/NameFormatter.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MichaelRubel\Formatters\Collection;
+
+use MichaelRubel\Formatters\Formatter;
+
+class NameFormatter implements Formatter
+{
+    /**
+     * @param  string|null  $name
+     */
+    public function __construct(public ?string $name)
+    {
+        //
+    }
+
+    /**
+     * Format the full name.
+     *
+     * @return string
+     */
+    public function format(): string
+    {
+        return str($this->name)
+            ->replaceMatches('/\p{C}+/u', '')
+            ->replace(['\r', '\n', '\t'], '')
+            ->squish()
+            ->value();
+    }
+}

--- a/src/Collection/NameFormatter.php
+++ b/src/Collection/NameFormatter.php
@@ -17,7 +17,7 @@ class NameFormatter implements Formatter
     }
 
     /**
-     * Format the full name.
+     * Format the generic name.
      *
      * @return string
      */

--- a/tests/NameFormatterTest.php
+++ b/tests/NameFormatterTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace MichaelRubel\Formatters\Tests;
+
+use MichaelRubel\Formatters\Collection\NameFormatter;
+
+class NameFormatterTest extends TestCase
+{
+    public function testSanitizesName()
+    {
+        $name = format(NameFormatter::class, '      Test Name     ');
+        $this->assertSame('Test Name', $name);
+    }
+
+    public function testRemovesUnixCodes()
+    {
+        $name = format(NameFormatter::class, ' Test\r\n\t Name ');
+        $this->assertSame('Test Name', $name);
+    }
+
+    public function testSanitizesInvisibleChars()
+    {
+        $name = format(NameFormatter::class, 'Test
+Name');
+        $this->assertSame('TestName', $name);
+    }
+
+    public function testCanUseStringBinding()
+    {
+        $name = format('name', 'Michael');
+
+        $this->assertSame('Michael', $name);
+    }
+
+    public function testEmptyString()
+    {
+        $name = format(NameFormatter::class, '');
+        $this->assertSame('', $name);
+
+        $name = format(NameFormatter::class, '   ');
+        $this->assertSame('', $name);
+    }
+}


### PR DESCRIPTION
## About

Adds a generic name formatted.

- Trims spaces at the start and at the end of the string;
- Removes line breaks and tabs.

---