### PR TITLE
Update `FullName` formatting behavior to handle names like `McKenzie`

### DIFF
--- a/src/Collection/FullNameFormatter.php
+++ b/src/Collection/FullNameFormatter.php
@@ -25,11 +25,11 @@ class FullNameFormatter implements Formatter
     {
         $words = str($this->name)->split('/\s/');
 
-        $name = $words->map(function (string $word) {
+        $this->name = $words->map(function (string $word) {
             return str($word)->ucfirst();
         })->join(' ');
 
-        return str($name)
+        return str($this->name)
             ->replaceMatches('/\p{C}+/u', '')
             ->squish()
             ->value();

--- a/src/Collection/FullNameFormatter.php
+++ b/src/Collection/FullNameFormatter.php
@@ -23,10 +23,15 @@ class FullNameFormatter implements Formatter
      */
     public function format(): string
     {
-        return str($this->name)
+        $words = str($this->name)->split('/\s/');
+
+        $name = $words->map(function (string $word) {
+            return str($word)->ucfirst();
+        })->join(' ');
+
+        return str($name)
             ->replaceMatches('/\p{C}+/u', '')
             ->squish()
-            ->title()
             ->value();
     }
 }

--- a/tests/FullNameFormatterTest.php
+++ b/tests/FullNameFormatterTest.php
@@ -29,9 +29,10 @@ class FullNameFormatterTest extends TestCase
 
     public function testCanFormatFirstAndLastName()
     {
-        $name = format(FullNameFormatter::class, 'michaeL rubéL');
-
+        $name = format(FullNameFormatter::class, 'michael rubél');
         $this->assertSame('Michael Rubél', $name);
+        $name = format(FullNameFormatter::class, 'michael mcKenzie');
+        $this->assertSame('Michael McKenzie', $name);
     }
 
     public function testCanFormatNameWithMinusSeparators()
@@ -39,7 +40,7 @@ class FullNameFormatterTest extends TestCase
         $name = format(FullNameFormatter::class, 'Anna Nowak-Kowalska');
         $this->assertSame('Anna Nowak-Kowalska', $name);
         $name = format(FullNameFormatter::class, ' anna nowak-kowalska ');
-        $this->assertSame('Anna Nowak-Kowalska', $name);
+        $this->assertSame('Anna Nowak-kowalska', $name);
     }
 
     public function testCutsSpaceBeforeAndAfter()


### PR DESCRIPTION
## About

Updates `FullName` to properly format names like `McKenzie`.

The underlying implementation splits the string into multiple words by spaces, then converts each word to uppercase format instead of converting the string to title-case.

---