### PR TITLE
Fix `LocaleNumberFormatter` extension ⚙

### DIFF
--- a/config/formatters.php
+++ b/config/formatters.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 return [
 
     /*

--- a/pint.json
+++ b/pint.json
@@ -2,6 +2,7 @@
   "preset": "laravel",
   "rules": {
     "phpdoc_separation": false,
+    "declare_strict_types": true,
     "concat_space": {
       "spacing": "one"
     },

--- a/src/Collection/DateFormatter.php
+++ b/src/Collection/DateFormatter.php
@@ -17,8 +17,8 @@ class DateFormatter implements Formatter
      */
     public function __construct(
         public string|null|CarbonInterface $date = null,
-        public string|null $timezone = null,
-        public string|null $date_format = 'Y-m-d',
+        public ?string $timezone = null,
+        public ?string $date_format = 'Y-m-d',
     ) {
         if (empty($this->date)) {
             $this->date = null;

--- a/src/Collection/DateTimeFormatter.php
+++ b/src/Collection/DateTimeFormatter.php
@@ -17,8 +17,8 @@ class DateTimeFormatter implements Formatter
      */
     public function __construct(
         public string|null|CarbonInterface $datetime = null,
-        public string|null $timezone = null,
-        public string|null $datetime_format = 'Y-m-d H:i',
+        public ?string $timezone = null,
+        public ?string $datetime_format = 'Y-m-d H:i',
     ) {
         if (empty($this->datetime)) {
             $this->datetime = null;

--- a/src/Collection/LocaleNumberFormatter.php
+++ b/src/Collection/LocaleNumberFormatter.php
@@ -27,13 +27,8 @@ class LocaleNumberFormatter implements Formatter
         public ?string $locale = null,
         public int $style = NumberFormatter::DECIMAL,
         public ?string $pattern = null,
-        public int $fraction_digits = 2
+        public int $fraction_digits = 2,
     ) {
-        $this->locale = $this->locale ?? app()->getLocale();
-
-        $this->formatter = new NumberFormatter($this->locale, $this->style, $this->pattern);
-
-        $this->formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $this->fraction_digits);
     }
 
     /**
@@ -45,6 +40,10 @@ class LocaleNumberFormatter implements Formatter
      */
     public function format(Collection $items): string|false
     {
+        $this->formatter = new NumberFormatter($this->locale ?? app()->getLocale(), $this->style, $this->pattern);
+
+        $this->formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $this->fraction_digits);
+
         return $this->formatter->format(
             (float) $this->number
         );

--- a/tests/DateFormatterTest.php
+++ b/tests/DateFormatterTest.php
@@ -128,14 +128,14 @@ class DateFormatterTest extends TestCase
     }
 
     /** @test */
-    public function testCanExtendDateTimeFormatter()
+    public function testCanExtendDateFormatter()
     {
         config(['app.timezone' => 'UTC']);
 
         $result = format(DateFormatter::class, '2021-10-31');
         $this->assertEquals('2021-10-31', $result);
 
-        app()->extend(DateFormatter::class, function ($service) {
+        $this->app->extend(DateFormatter::class, function ($service) {
             $service->timezone    = 'Europe/Warsaw';
             $service->date_format = 'd-m-Y';
 

--- a/tests/DateFormatterTest.php
+++ b/tests/DateFormatterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MichaelRubel\Formatters\Tests;
 
 use Carbon\Carbon;

--- a/tests/DateTimeFormatterTest.php
+++ b/tests/DateTimeFormatterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MichaelRubel\Formatters\Tests;
 
 use Carbon\Carbon;

--- a/tests/FormatterBindingsTest.php
+++ b/tests/FormatterBindingsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MichaelRubel\Formatters\Tests;
 
 use Illuminate\Support\Facades\File;

--- a/tests/FormatterConfigTest.php
+++ b/tests/FormatterConfigTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MichaelRubel\Formatters\Tests;
 
 use Illuminate\Filesystem\Filesystem;
@@ -13,8 +15,8 @@ class FormatterConfigTest extends TestCase
     {
         $mock = $this->partialMock(Filesystem::class, function (MockInterface $mock) {
             $mock->shouldReceive('isDirectory')
-                 ->once()
-                 ->andReturnFalse();
+                ->once()
+                ->andReturnFalse();
         });
 
         app()->instance('files', $mock);

--- a/tests/FullNameFormatterTest.php
+++ b/tests/FullNameFormatterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MichaelRubel\Formatters\Tests;
 
 use MichaelRubel\Formatters\Collection\FullNameFormatter;

--- a/tests/LocaleNumberFormatterTest.php
+++ b/tests/LocaleNumberFormatterTest.php
@@ -1,9 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MichaelRubel\Formatters\Tests;
 
 use MichaelRubel\Formatters\Collection\LocaleNumberFormatter;
-use MichaelRubel\Formatters\Collection\TaxNumberFormatter;
 
 class LocaleNumberFormatterTest extends TestCase
 {

--- a/tests/LocaleNumberFormatterTest.php
+++ b/tests/LocaleNumberFormatterTest.php
@@ -3,6 +3,7 @@
 namespace MichaelRubel\Formatters\Tests;
 
 use MichaelRubel\Formatters\Collection\LocaleNumberFormatter;
+use MichaelRubel\Formatters\Collection\TaxNumberFormatter;
 
 class LocaleNumberFormatterTest extends TestCase
 {
@@ -179,5 +180,21 @@ class LocaleNumberFormatterTest extends TestCase
         );
 
         $this->assertSame('10,000.00', $result);
+    }
+
+    /** @test */
+    public function testCanExtendLocaleNumberFormatter()
+    {
+        $this->app->extend(LocaleNumberFormatter::class, function ($formatter) {
+            $formatter->locale = 'fr';
+
+            return $formatter;
+        });
+
+        $result = $this->trimSpecialCharacters(
+            format(LocaleNumberFormatter::class, 10000.5550)
+        );
+
+        $this->assertEquals('10 000,56', $result);
     }
 }

--- a/tests/MakeFormatterCommandTest.php
+++ b/tests/MakeFormatterCommandTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MichaelRubel\Formatters\Tests;
 
 use Illuminate\Support\Facades\File;

--- a/tests/MaskStringFormatterTest.php
+++ b/tests/MaskStringFormatterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MichaelRubel\Formatters\Tests;
 
 use MichaelRubel\Formatters\Collection\MaskStringFormatter;
@@ -59,11 +61,11 @@ class MaskStringFormatterTest extends TestCase
             $formatter->length    = -5;
             $formatter->encoding  = 'KOI8-U';
 
-            $this->assertStringContainsString('test@example.com', $formatter->string);
-            $this->assertStringContainsString('%', $formatter->character);
-            $this->assertStringContainsString(5, $formatter->index);
-            $this->assertStringContainsString(-5, $formatter->length);
-            $this->assertStringContainsString('KOI8-U', $formatter->encoding);
+            $this->assertSame('test@example.com', $formatter->string);
+            $this->assertSame('%', $formatter->character);
+            $this->assertSame(5, $formatter->index);
+            $this->assertSame(-5, $formatter->length);
+            $this->assertSame('KOI8-U', $formatter->encoding);
 
             return $formatter;
         });

--- a/tests/NameFormatterTest.php
+++ b/tests/NameFormatterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MichaelRubel\Formatters\Tests;
 
 use MichaelRubel\Formatters\Collection\NameFormatter;

--- a/tests/TableColumnFormatterTest.php
+++ b/tests/TableColumnFormatterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MichaelRubel\Formatters\Tests;
 
 use MichaelRubel\Formatters\Collection\TableColumnFormatter;

--- a/tests/TaxNumberFormatterTest.php
+++ b/tests/TaxNumberFormatterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MichaelRubel\Formatters\Tests;
 
 use MichaelRubel\Formatters\Collection\TaxNumberFormatter;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MichaelRubel\Formatters\Tests;
 
 use MichaelRubel\Formatters\FormatterServiceProvider;


### PR DESCRIPTION
## About

Fix the extension mechanism for the locale number formatter.

---